### PR TITLE
Use user-specific Qdrant collection for document deletion

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -140,7 +140,7 @@ async def chat_document_delete(chat_id: str, document_id: str, user_jwt: Annotat
         return {"error": "Not a valid Document"}
     sql_connection.cursor().execute(f"DELETE FROM `{mariadb_name(user_id, chat_id)}`.documents WHERE id='{document_id}';")
     qdrant.delete(
-        collection_name=chat_id,
+        collection_name=f"{user_id}-{chat_id}",
         points_selector=[document_id],
         wait=True,
     )


### PR DESCRIPTION
## Summary
- ensure document deletions target user-specific Qdrant collections

## Testing
- `pytest` *(fails: NameError: name 'get_rules' is not defined; TypeError: one of the hex, bytes, bytes_le, fields, or int arguments must be given)*

------
https://chatgpt.com/codex/tasks/task_e_6898c45b9d34832fb7750181cf0fb634