### PR TITLE
Sort chat history by message ID

### DIFF
--- a/app/chat_endpoint_handlers.py
+++ b/app/chat_endpoint_handlers.py
@@ -104,7 +104,9 @@ async def chat_history_success(chat_id, user_id):
     messages = []
     sql_connection.ping()
     cursor = sql_connection.cursor()
-    cursor.execute(f"SELECT creator, content, aid FROM `{mariadb_name(user_id, chat_id)}`.messages;")
+    cursor.execute(
+        f"SELECT creator, content, aid FROM `{mariadb_name(user_id, chat_id)}`.messages ORDER BY aid;"
+    )
     old_messages = cursor.fetchall()
     for message in old_messages:
         messages.append({


### PR DESCRIPTION
## Summary
- ensure chat history queries return messages in chronological order

## Testing
- `pytest -q` (fails: NameError: name 'get_rules' is not defined)


------
https://chatgpt.com/codex/tasks/task_e_6898c468a9c0832f93f26a92dd39e616