### PR TITLE
Remove internal MongoDB ID from character responses

### DIFF
--- a/app/chat_endpoint_handlers.py
+++ b/app/chat_endpoint_handlers.py
@@ -81,6 +81,7 @@ async def chat_characters_success(chat_id, user_id):
     fixed_data = []
     for character in data:
         character["id"] = character["_id"]["$oid"]
+        del character["_id"]
         fixed_data.append(character)
     return {"characters": fixed_data}
 


### PR DESCRIPTION
## Summary
- Exclude MongoDB `_id` from character list responses to avoid leaking internal IDs

## Testing
- `pytest -q` *(fails: NameError: name 'get_rules' is not defined; TypeError: one of the hex, bytes, bytes_le, fields, or int arguments must be given)*

------
https://chatgpt.com/codex/tasks/task_e_6898c46f906c832f88099252c976b67c