### PR TITLE
Use parameterized query for document deletion

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -138,7 +138,10 @@ async def chat_document_delete(chat_id: str, document_id: str, user_jwt: Annotat
         return {"error": "Not a valid Chat"}
     if not is_uuid_like(document_id):
         return {"error": "Not a valid Document"}
-    sql_connection.cursor().execute(f"DELETE FROM `{mariadb_name(user_id, chat_id)}`.documents WHERE id='{document_id}';")
+    sql_connection.cursor().execute(
+        f"DELETE FROM `{mariadb_name(user_id, chat_id)}`.documents WHERE id=?;",
+        [document_id],
+    )
     qdrant.delete(
         collection_name=chat_id,
         points_selector=[document_id],


### PR DESCRIPTION
## Summary
- use a parameterized SQL query when deleting documents by ID to avoid injection issues

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'mariadb')*


------
https://chatgpt.com/codex/tasks/task_e_6898c451de4c832f9a912542b1f58314