### PR TITLE
fix: height of send btn

### DIFF
--- a/ui/src/styles.scss
+++ b/ui/src/styles.scss
@@ -546,6 +546,12 @@ nav, footer {
 }
 #send {
   font-size: 2em;
+  line-height: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background-size: 100% 100%;
+  background-repeat: no-repeat;
 }
 #fontmode, #colormode {
   color: transparent;


### PR DESCRIPTION
## 📝 Description

Fix mismatch between the Send button’s visual background and its height at certain resolutions/DPI.

Changes:

- Update UI CSS for the Send button (id="send") to ensure consistent rendering across viewport sizes and device pixel ratios:

  - Enforce consistent line-height
  - Use flex-based centering for stable vertical alignment
  - Ensure background paints the full element box

---

## ✅ Issues

Closes #385

---

## 🔍 Type of Change

<!-- Check all that apply -->
- [x] 🐛 Bug Fix
- [ ] ✨ New Feature
- [ ] 🧪 Test Case
- [ ] 📝 Documentation
- [ ] 🔧 Refactor
- [ ] 🔄 Other (please explain)

---

## ⚠️ Breaking Changes

None.

The CSS change is scoped to the #send button only. No behavioral changes and no impact to other buttons or components.

---

## 🧪 How Has This Been Tested?

<!-- Explain how you tested your changes. Include commands, results, and coverage. -->
- [ ] Added/updated unit and/or integration tests
- [x] Manually verified locally

---

## 📸 Screenshots (if UI-related)

<img width="1916" height="216" alt="image" src="https://github.com/user-attachments/assets/c81bdcde-f8f9-453d-a69c-0587c18fd509" />

---

## 📋 Checklist

- [x] I have followed the contribution guidelines (see CONTRIBUTING.md)
- [x] I have self-reviewed my changes
- [ ] I have added or updated tests as appropriate
- [ ] I have tested these changes locally and confirmed expected behaviour
- [ ] I have updated documentation where necessary
- [x] I have linked related issues if applicable
- [x] No secrets or sensitive data are present in code, logs, or screenshots
- [ ] For UI changes: I have considered accessibility (a11y) and provided alt text
- [ ] If breaking changes exist, I have documented them above