### PR TITLE
fix: add dark background on loading

### DIFF
--- a/ui/src/styles.scss
+++ b/ui/src/styles.scss
@@ -294,8 +294,10 @@ input, textarea, select {
   height: 100%;
   position: absolute;
   left: 0;
+  top: 0;
   bottom: 0;
-  background: var(--medium-shadow);
+  z-index: var(--overlay-z-index);
+  background: var(--modal-bg);
 
   > img {
     display: block;


### PR DESCRIPTION
## 📝 Description

Updated the loading overlay styling to be darker and feel non-interactive. The `#loader` background now uses the modal background `(var(--modal-bg), ~80% opacity)` instead of a light shadow, covers the full `viewport (added top: 0)`, and ensures proper stacking with `z-index: var(--overlay-z-index)`. This makes the loading state consistent with modal styling and prevents the UI underneath from looking clickable.

---

Closes #380 

---

## 🔍 Type of Change

<!-- Check all that apply -->
- [x] 🐛 Bug Fix
- [ ] ✨ New Feature
- [ ] 🧪 Test Case
- [ ] 📝 Documentation
- [ ] 🔧 Refactor
- [ ] 🔄 Other (please explain)

---

## 🧪 How Has This Been Tested?

<!-- Explain how you tested your changes. Include commands, results, and coverage. -->
- [ ] Added/updated unit and/or integration tests
- [x] Manually verified locally

---

## 📋 Checklist

- [x] I have followed the contribution guidelines (see CONTRIBUTING.md)
- [x] I have self-reviewed my changes
- [ ] I have added or updated tests as appropriate
- [x] I have tested these changes locally and confirmed expected behaviour
- [ ] I have updated documentation where necessary
- [x] I have linked related issues if applicable
- [x] No secrets or sensitive data are present in code, logs, or screenshots
- [ ] For UI changes: I have considered accessibility (a11y) and provided alt text
- [ ] If breaking changes exist, I have documented them above