### PR TITLE
Center contributor images in incomplete final row (#405)

### DIFF
--- a/github-cache/main.py
+++ b/github-cache/main.py
@@ -106,7 +106,12 @@ async def process_contributors():
             for i, avatar in enumerate(avatars):
                 row = i // avatars_per_row
                 col = i % avatars_per_row
-                x = 10 + col * (avatar_size + padding)
+                
+                avatars_in_this_row = avatars_per_row if (row < rows -1) else (len(avatars) % avatars_per_row or avatars_per_row)
+                row_width = avatars_in_this_row * (avatar_size + padding) - padding
+                offset_x = (width - row_width) // 2
+
+                x = offset_x + col * (avatar_size + padding)
                 y = 10 + row * (avatar_size + 20 + padding)
 
                 image.paste(avatar, (x, y), avatar)


### PR DESCRIPTION
# 📦 Pull Request: Center Contributor Images (#405)

## 📝 Summary
Centers contributor images for rows that are not full (fixes visual alignment when the last row has fewer avatars).

## ✅ Related Issue
Fixes #405

## 🔍 What I Changed
- Calculate `avatars_in_this_row` for each row (handles last row).  
- Compute `row_width` and horizontal `offset_x` to center the row.  
- Adjust avatar paste x-coordinate to include offset.  

## 🧪 How To Test Locally
1. Clone your fork and checkout branch `fix/center-contributors-405` (or pull my branch).  
2. Install dependencies: `pip install aiohttp Pillow`.  
3. Run `python github-cache/main.py`.  
4. Open `contributors_output/contributors.png` and verify last row is centered for non-full rows.  

## 📸 Screenshots
<img width="1020" height="482" alt="before" src="https://github.com/user-attachments/assets/5f31c20d-18c3-4ab8-8227-9e92d1ac87d0" />
<img width="2110" height="672" alt="after" src="https://github.com/user-attachments/assets/c6462577-5190-4ed1-8245-745dca465cad" />

## 📝 Notes
- No API changes.  
- Only visual layout change for contributor image generation.  
- CC: @Idrinth, @bjoern-buettner


